### PR TITLE
Add function to join patches

### DIFF
--- a/src/dataset/composer.py
+++ b/src/dataset/composer.py
@@ -3,7 +3,7 @@
 # preprocessing functions.                                                                                            #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable, Dict, List, Tuple
 
 import numpy as np
 
@@ -34,3 +34,44 @@ class OrderedCompose:
             image, annotations = func(image, annotations, **self.kwargs)
 
         return image, annotations
+
+
+def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
+    if len(patches) == 0:
+        raise ValueError("Input list of patches is empty.")
+
+    
+    dimensions = [x_y_from_filename(filename) for filename in filenames]
+    result_shape = calculate_result_shape_from_patches(patches, dimensions)
+    result_image = np.zeros((result_shape[0], result_shape[1]), dtype=np.uint8)
+
+    for (x_result_image, y_result_image), patch in zip(dimensions, patches):
+        height, width = patch.shape
+
+        result_image[
+            x_result_image:x_result_image+height, 
+            y_result_image:y_result_image+width
+        ] = np.maximum(
+            result_image[x_result_image:x_result_image+height, y_result_image:y_result_image+width],
+            patch
+            )
+
+    return result_image
+
+
+def calculate_result_shape_from_patches(patches: List[np.ndarray], dimensions: Tuple[int, int]) -> Tuple[int, int]:
+    max_x = 0
+    max_y = 0
+    for (x, y), patch in zip(dimensions, patches):
+        patch_height, patch_width = patch.shape
+        if x + patch_width > max_x: max_x = x + patch_width
+        if y + patch_height > max_y: max_y = y + patch_height
+
+    return (max_x, max_y)
+
+
+def x_y_from_filename(filename: str) -> tuple[int, int]:
+    x = int(filename.split("_")[1])
+    y = int(filename.split("_")[2].split(".")[0])
+    
+    return [x, y]

--- a/src/dataset/composer.py
+++ b/src/dataset/composer.py
@@ -70,7 +70,8 @@ def calculate_result_shape_from_patches(patches: List[np.ndarray], dimensions: T
 
 
 def x_y_from_filename(filename: str) -> Tuple[int, int]:
-    x = int(filename.split("_")[1])
-    y = int(filename.split("_")[2].split(".")[0])
+    split_by_underscore = filename.split("_")
+    x = int(split_by_underscore[1])
+    y = int(split_by_underscore[2].split(".")[0])
     
     return (x, y)

--- a/src/dataset/composer.py
+++ b/src/dataset/composer.py
@@ -39,7 +39,6 @@ class OrderedCompose:
 def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
     if len(patches) == 0:
         raise ValueError("Input list of patches is empty.")
-
     
     dimensions = [x_y_from_filename(filename) for filename in filenames]
     result_shape = calculate_result_shape_from_patches(patches, dimensions)

--- a/src/dataset/composer.py
+++ b/src/dataset/composer.py
@@ -39,21 +39,20 @@ class OrderedCompose:
 def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
     if len(patches) == 0:
         raise ValueError("Input list of patches is empty.")
-    
-    dimensions = [x_y_from_filename(filename) for filename in filenames]
-    result_shape = calculate_result_shape_from_patches(patches, dimensions)
+
+    patches_positions = [x_y_from_filename(filename) for filename in filenames]
+    result_shape = calculate_result_shape_from_patches(patches, patches_positions)
     result_image = np.zeros(result_shape, dtype=np.uint8)
 
-    for (x_result_image, y_result_image), patch in zip(dimensions, patches):
+    for (y_at_result_image, x_at_result_image), patch in zip(patches_positions, patches):
         height, width = patch.shape
 
         result_image[
-            x_result_image:x_result_image+height, 
-            y_result_image:y_result_image+width
+            y_at_result_image:y_at_result_image + height,
+            x_at_result_image:x_at_result_image + width
         ] = np.maximum(
-            result_image[x_result_image:x_result_image+height, y_result_image:y_result_image+width],
-            patch
-            )
+            result_image[y_at_result_image:y_at_result_image + height, x_at_result_image:x_at_result_image + width],
+            patch)
 
     return result_image
 
@@ -63,8 +62,10 @@ def calculate_result_shape_from_patches(patches: List[np.ndarray], dimensions: T
     max_y = 0
     for (x, y), patch in zip(dimensions, patches):
         patch_height, patch_width = patch.shape
-        if x + patch_width > max_x: max_x = x + patch_width
-        if y + patch_height > max_y: max_y = y + patch_height
+        if x + patch_width > max_x:
+            max_x = x + patch_width
+        if y + patch_height > max_y:
+            max_y = y + patch_height
 
     return (max_x, max_y)
 
@@ -73,5 +74,5 @@ def x_y_from_filename(filename: str) -> Tuple[int, int]:
     split_by_underscore = filename.split("_")
     x = int(split_by_underscore[1])
     y = int(split_by_underscore[2].split(".")[0])
-    
+
     return (x, y)

--- a/src/dataset/composer.py
+++ b/src/dataset/composer.py
@@ -3,7 +3,7 @@
 # preprocessing functions.                                                                                            #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List
 
 import numpy as np
 
@@ -34,45 +34,3 @@ class OrderedCompose:
             image, annotations = func(image, annotations, **self.kwargs)
 
         return image, annotations
-
-
-def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
-    if len(patches) == 0:
-        raise ValueError("Input list of patches is empty.")
-
-    patches_positions = [x_y_from_filename(filename) for filename in filenames]
-    result_shape = calculate_result_shape_from_patches(patches, patches_positions)
-    result_image = np.zeros(result_shape, dtype=np.uint8)
-
-    for (y_at_result_image, x_at_result_image), patch in zip(patches_positions, patches):
-        height, width = patch.shape
-
-        result_image[
-            y_at_result_image:y_at_result_image + height,
-            x_at_result_image:x_at_result_image + width
-        ] = np.maximum(
-            result_image[y_at_result_image:y_at_result_image + height, x_at_result_image:x_at_result_image + width],
-            patch)
-
-    return result_image
-
-
-def calculate_result_shape_from_patches(patches: List[np.ndarray], dimensions: Tuple[int, int]) -> Tuple[int, int]:
-    max_x = 0
-    max_y = 0
-    for (x, y), patch in zip(dimensions, patches):
-        patch_height, patch_width = patch.shape
-        if x + patch_width > max_x:
-            max_x = x + patch_width
-        if y + patch_height > max_y:
-            max_y = y + patch_height
-
-    return (max_x, max_y)
-
-
-def x_y_from_filename(filename: str) -> Tuple[int, int]:
-    split_by_underscore = filename.split("_")
-    x = int(split_by_underscore[1])
-    y = int(split_by_underscore[2].split(".")[0])
-
-    return (x, y)

--- a/src/dataset/composer.py
+++ b/src/dataset/composer.py
@@ -42,7 +42,7 @@ def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
     
     dimensions = [x_y_from_filename(filename) for filename in filenames]
     result_shape = calculate_result_shape_from_patches(patches, dimensions)
-    result_image = np.zeros((result_shape[0], result_shape[1]), dtype=np.uint8)
+    result_image = np.zeros(result_shape, dtype=np.uint8)
 
     for (x_result_image, y_result_image), patch in zip(dimensions, patches):
         height, width = patch.shape
@@ -69,8 +69,8 @@ def calculate_result_shape_from_patches(patches: List[np.ndarray], dimensions: T
     return (max_x, max_y)
 
 
-def x_y_from_filename(filename: str) -> tuple[int, int]:
+def x_y_from_filename(filename: str) -> Tuple[int, int]:
     x = int(filename.split("_")[1])
     y = int(filename.split("_")[2].split(".")[0])
     
-    return [x, y]
+    return (x, y)

--- a/src/dataset/dataset_utils.py
+++ b/src/dataset/dataset_utils.py
@@ -72,7 +72,7 @@ def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
     if len(patches) == 0:
         raise ValueError("Input list of patches is empty.")
 
-    patches_positions = [x_y_from_filename(filename) for filename in filenames]
+    patches_positions = [x_y_from_filename(filename_from_path(filename)) for filename in filenames]
     result_shape = calculate_result_shape_from_patches(patches, patches_positions)
     result_image = np.zeros(result_shape, dtype=np.uint8)
 
@@ -121,3 +121,17 @@ def x_y_from_filename(filename: str) -> Tuple[int, int]:
     y = int(split_by_underscore[2].split(".")[0])
 
     return (x, y)
+
+def filename_from_path(path: str) -> str:
+    """Extracts filename from a path. Robus enough to receive a filename and
+    return if if not a path.
+    
+    Args:
+        path (str): A path to a file.
+        
+    Returns:
+        str: The extracted filename.
+    """
+    basename = os.path.basename(path)
+    filename, _ = os.path.splitext(basename)
+    return filename

--- a/src/dataset/dataset_utils.py
+++ b/src/dataset/dataset_utils.py
@@ -3,7 +3,7 @@
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
 import os
-from typing import List
+from typing import List, Tuple
 
 import cv2
 import numpy as np
@@ -51,3 +51,73 @@ def read_paths(directory_path: str) -> List[str]:
         raise ValueError(f"Path {directory_path} is not a directory.")
 
     return os.listdir(directory_path)
+
+
+@staticmethod
+def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
+    """Joins a list of patches into a single image.
+
+    Args:
+        patches (List[np.ndarray]): The patches to join.
+        filenames (List[str]): The filenames for the patches in the format <name>_x_y.<ext> 
+        where x and y represent a position of the patch in the original image.
+
+    Returns:
+        np.ndarray: A single image with all the patches merged together. When pixels collide
+        in two or more patches, the greather value is used.
+
+    Raises:
+        ValueError: If no patches are provided as input.
+    """
+    if len(patches) == 0:
+        raise ValueError("Input list of patches is empty.")
+
+    patches_positions = [x_y_from_filename(filename) for filename in filenames]
+    result_shape = calculate_result_shape_from_patches(patches, patches_positions)
+    result_image = np.zeros(result_shape, dtype=np.uint8)
+
+    for (init_y, init_x), patch in zip(patches_positions, patches):
+        row, col = patch.shape
+
+        result_image[
+            init_y:init_y + row,
+            init_x:init_x + col
+        ] = np.maximum(
+            result_image[init_y:init_y + row, init_x:init_x + col],
+            patch)
+
+    return result_image
+
+
+def calculate_result_shape_from_patches(patches: List[np.ndarray], dimensions: Tuple[int, int]) -> Tuple[int, int]:
+    """Given a set of patches, calculates the resulting size of an image that contains all patches.
+
+    Args:
+        patches (List[np.ndarray]): The patches involved in the operation.
+        dimensions (Tuple[int, int]): A list of coordinates (x, y) of where, in the original images,
+        each patch is positioned.
+
+    Returns:
+        Tuple[int, int]: The size of each dimension of the resulting calculated image.
+    """
+    coords = list(zip(*dimensions))
+    shapes = list(zip(*[patch.shape[:2] for patch in patches]))
+    image_shape = np.max(np.array(shapes) + np.array(coords), axis=1)
+
+    return image_shape
+
+
+def x_y_from_filename(filename: str) -> Tuple[int, int]:
+    """Extracts x and y coordinates from a filename in the format <name>_x_y.<ext>.
+
+    Args:
+        filename (str): The name of the file in the expected format.
+
+    Returns:
+        Tuple[int, int]: The x and y coordinates extracted from the filename.
+    """
+    split_by_underscore = filename.split("_")
+    x = int(split_by_underscore[1])
+    y = int(split_by_underscore[2].split(".")[0])
+
+    return (x, y)

--- a/src/dataset/dataset_utils.py
+++ b/src/dataset/dataset_utils.py
@@ -71,20 +71,15 @@ def join_patches(patches: List[np.ndarray], filenames: List[str]) -> np.ndarray:
     """
     if len(patches) == 0:
         raise ValueError("Input list of patches is empty.")
-
+    
+    patches = [patch.astype(np.uint8) for patch in patches]
     patches_positions = [x_y_from_filename(filename_from_path(filename)) for filename in filenames]
     result_shape = calculate_result_shape_from_patches(patches, patches_positions)
     result_image = np.zeros(result_shape, dtype=np.uint8)
 
     for (init_y, init_x), patch in zip(patches_positions, patches):
         row, col = patch.shape
-
-        result_image[
-            init_y:init_y + row,
-            init_x:init_x + col
-        ] = np.maximum(
-            result_image[init_y:init_y + row, init_x:init_x + col],
-            patch)
+        result_image[init_y:init_y + row, init_x:init_x + col] |= patch
 
     return result_image
 


### PR DESCRIPTION
Closes #9 

I tested this code with the following unit testing structure (varying to validate things), but I didn't want to push this because I'm not sure about the unit testing structure:

```python
import numpy as np
import unittest

from composer import join_patches

class TestJoinPatches(unittest.TestCase):

    def setup_class(cls):
        pass

    def teardown_class(cls):
        pass

    def test_join_patches(self):

        image_4x3 = np.array([
                        [1, 1, 1, 1],
                        [1, 1, 1, 1],
                        [1, 1, 1, 1]])
        filename_4x3 = "arrobas_0_0.jpg"

        image_4x4 = np.array([
                        [1, 1, 1, 0],
                        [0, 1, 1, 0],
                        [0, 1, 1, 0],
                        [0, 1, 0, 0]])
        filename_4x4 = "arrobas_9_9.jpg"

        patches = [image_4x3, image_4x4]
        filenames = [filename_4x3, filename_4x4]

        result = join_patches(patches=patches, filenames=filenames)
        print(result)


if __name__ == '__main__':
    unittest.main()
```