### PR TITLE
Fix patch generation to extend the image bounds if necessary.

### DIFF
--- a/src/dataset/dataset_coco.py
+++ b/src/dataset/dataset_coco.py
@@ -319,38 +319,32 @@ class CocoDatasetInstanceSegmentation(CocoDataset):
 
 
 def extended_dimensions(patch_size: int, stride: int, image_shape: Tuple[int, ...]) -> Tuple[int, ...]:
-    # TODO test cases with strides greater than patch_size
+    """Calculate the extended dimensions of an image based on the patch size and stride.
+    
+    If for a given dimension, considering the patch_size and the stride, the image will perfectly fit
+    all patches, nothing is done.
+    
+    However, if a dimension doesn't fit patches perfectly, then the dimension is extended in order to
+    guarantee that.
+    
+    The new size of the dimension is calculated by taking the last multiple of stride within the
+    dimension and adding the size of a patch to it. With this operation, this extended dimension
+    now fits patches perfectly considering their size and stride.    
+
+    Args:
+        patch_size (int): The size of the patch.
+        stride (int): The stride between patches.
+        image_shape (Tuple[int, ...]): The shape of the image.
+
+    Returns:
+        Tuple[int, ...]: The extended dimensions of the image.
+
+    """
     return [
         image_shape[i]
+        # do not extend if patches fit perfectly in the image
         if (image_shape[i] - patch_size) % stride == 0
+        # calculate the last multiple of stride + patch_size, which ensures patches fit perfectly.
         else (((image_shape[i] // stride) * stride) + patch_size)
         for i in range(len(image_shape))
     ]
-
-    # L = 9; P = 3; S = 4
-    # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
-    # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
-    # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
-    # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
-    # X X X X X X X X X  X X X X X X X X X  X X X X X X X X X
-    # Need to add 1 column.
-
-    # L = 11; P = 4; S = 3
-    # o o o o X X X X X X X  X X X o o o o X X X X  X X X X X X o o o o X  X X X X X X X X X o o o o
-    # o o o o X X X X X X X  X X X o o o o X X X X  X X X X X X o o o o X  X X X X X X X X X o o o o
-    # o o o o X X X X X X X  X X X o o o o X X X X  X X X X X X o o o o X  X X X X X X X X X o o o o
-    # o o o o X X X X X X X  X X X o o o o X X X X  X X X X X X o o o o X  X X X X X X X X X o o o o
-    # X X X X X X X X X X X  X X X X X X X X X X X  X X X X X X X X X X X  X X X X X X X X X X X
-    # Need to add 2 columns.
-
-    # L = 10; P = 4; S = 2
-    # o o o o X X X X X X  X X o o o o X X X X  X X X X o o o o X X  X X X X X X o o o o
-    # o o o o X X X X X X  X X o o o o X X X X  X X X X o o o o X X  X X X X X X o o o o
-    # o o o o X X X X X X  X X o o o o X X X X  X X X X o o o o X X  X X X X X X o o o o
-    # o o o o X X X X X X  X X o o o o X X X X  X X X X o o o o X X  X X X X X X o o o o
-    # X X X X X X X X X X  X X X X X X X X X X  X X X X X X X X X X  X X X X X X X X X X
-    # No need to add columns
-
-    # L = 9; P = 3; S = 2
-    # o o o X X X X X X  X X o o o X X X X  X X X X o o o X X  X X X X o o o X X  X X X X X X o o o
-    # No need to add columns

--- a/src/dataset/dataset_coco.py
+++ b/src/dataset/dataset_coco.py
@@ -2,7 +2,6 @@
 # A COCO dataset class that should be used with PyTorch.                                                              #
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~#
 
-import math
 import os
 from copy import deepcopy
 from dataclasses import dataclass

--- a/src/dataset/dataset_coco.py
+++ b/src/dataset/dataset_coco.py
@@ -242,16 +242,16 @@ class CocoDatasetInstanceSegmentation(CocoDataset):
 
         for image_data in tqdm(self.images):
             image_path = os.path.join(self.data_directory_path, image_data["file_name"])
-            
+
             if image_data["id"] not in self.annotations.keys():
                 continue
-            
+
             image_annotations = self.annotations[image_data["id"]]
 
             image = read_image(image_path)
 
             # ~~ Extend mask dimensions to match with patch_size and stride values.
-            extended_image = np.zeros(extended_dimensions(patch_size, stride, image.shape))
+            extended_image = np.zeros(extended_dimensions(patch_size, stride, image.shape[:2]))
 
             # ~~ Draw components on masks based on the image annotations made on CVAT.
             binary_mask = generate_binary_mask(extended_image, image_annotations)
@@ -320,16 +320,19 @@ class CocoDatasetInstanceSegmentation(CocoDataset):
 
 def extended_dimensions(patch_size: int, stride: int, image_shape: Tuple[int, ...]) -> Tuple[int, ...]:
     # TODO test cases with strides greater than patch_size
-    return [image_shape[i] if (image_shape[i] - patch_size) % stride == 0 
-                  else (((image_shape[i] // stride) * stride) + patch_size)
-                  for i in range(len(image_shape))]
+    return [
+        image_shape[i]
+        if (image_shape[i] - patch_size) % stride == 0
+        else (((image_shape[i] // stride) * stride) + patch_size)
+        for i in range(len(image_shape))
+    ]
 
     # L = 9; P = 3; S = 4
     # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
     # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
     # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
     # o o o o X X X X X  X X X o o o o X X  X X X X X X o o o o
-    # X X X X X X X X X  X X X X X X X X X  X X X X X X X X X 
+    # X X X X X X X X X  X X X X X X X X X  X X X X X X X X X
     # Need to add 1 column.
 
     # L = 11; P = 4; S = 3

--- a/src/dataset/dataset_utils.py
+++ b/src/dataset/dataset_utils.py
@@ -129,6 +129,7 @@ def generate_category_mask(image: np.ndarray, annotations: Dict) -> np.ndarray:
 
 def patch_generator(image: np.ndarray, patch_size: int, stride: int) -> Tuple[np.ndarray, Tuple[int, int]]:
     """Generate patches from an image using a sliding window approach.
+    Patch size is fixed. Patches that would be smaller are filled with zeros.
 
     Args:
         image (np.ndarray): The input image.
@@ -148,7 +149,11 @@ def patch_generator(image: np.ndarray, patch_size: int, stride: int) -> Tuple[np
 
     while cur_row < rows:
         coord = (cur_row, cur_col)
-        patch = image[cur_row : min(cur_row + patch_size, rows - 1), cur_col : min(cur_col + patch_size, cols - 1)]
+
+        patch = np.zeros((patch_size, patch_size), dtype=image.dtype)
+        patch_rows = min(patch_size, rows - cur_row)
+        patch_cols = min(patch_size, cols - cur_col)
+        patch[:patch_rows, :patch_cols] = image[cur_row:cur_row + patch_rows, cur_col:cur_col + patch_cols]
 
         if cur_col + patch_size >= cols - 1:
             previous_was_inside = cur_row - stride + patch_size < rows - 1

--- a/src/dataset/test_dataset_coco.py
+++ b/src/dataset/test_dataset_coco.py
@@ -1,0 +1,42 @@
+import unittest
+import tempfile
+import shutil
+import os
+from src.dataset.dataset_coco import CocoDatasetInstanceSegmentation
+from src.dataset.dataset_coco import extended_dimensions
+
+class TestCocoDataset(unittest.TestCase):
+    # def test_extract_patches(self):
+    #     with tempfile.TemporaryDirectory() as temp_dir:
+    #         print(f'The path for the output is {temp_dir}')
+    #         dataset = CocoDatasetInstanceSegmentation(data_directory_path='./data/1/images',
+    #                                                   data_annotation_path='./data/1/annotations/instances_default.json')
+
+    #         output_dir = os.path.join(temp_dir, 'output_patches')
+    #         patch_size = 64 
+    #         stride = 13
+    #         min_area = 100.0
+    #         dataset.extract_patches(output_dir, patch_size, stride, min_area)
+
+    #         self.assertTrue(os.path.exists(output_dir))
+    #         self.assertTrue(os.path.exists(os.path.join(output_dir, 'images')))
+    #         self.assertTrue(os.path.exists(os.path.join(output_dir, 'annotations')))
+    #         self.assertTrue(os.path.exists(os.path.join(output_dir, 'annotations', 'annotations.json')))
+            
+    def test_extended_dimensions(self):
+        
+        assert(extended_dimensions(4, 2, [10, 10]) == [10, 10])
+        assert(extended_dimensions(4, 3, [11, 11]) == [13, 13])
+        assert(extended_dimensions(4, 2, [12, 12]) == [12, 12])
+        assert(extended_dimensions(4, 2, [13, 13]) == [16, 16])
+        assert(extended_dimensions(3, 2, [9, 9]) == [9, 9])
+        assert(extended_dimensions(3, 1, [10, 10]) == [10, 10])
+        
+        # For stride=1 there's no need to extend dimensions never.
+        assert(extended_dimensions(256, 1, [5000, 5000]) == [5000, 5000])
+        assert(extended_dimensions(256, 1, [50000, 50000000]) == [50000, 50000000])
+        assert(extended_dimensions(256, 1, [123456, 987654]) == [123456, 987654])
+        assert(extended_dimensions(256, 1, [1122554466, 12]) == [1122554466, 12])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/dataset/test_dataset_coco.py
+++ b/src/dataset/test_dataset_coco.py
@@ -6,22 +6,22 @@ from src.dataset.dataset_coco import CocoDatasetInstanceSegmentation
 from src.dataset.dataset_coco import extended_dimensions
 
 class TestCocoDataset(unittest.TestCase):
-    # def test_extract_patches(self):
-    #     with tempfile.TemporaryDirectory() as temp_dir:
-    #         print(f'The path for the output is {temp_dir}')
-    #         dataset = CocoDatasetInstanceSegmentation(data_directory_path='./data/1/images',
-    #                                                   data_annotation_path='./data/1/annotations/instances_default.json')
+    def test_extract_patches(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            print(f'The path for the output is {temp_dir}')
+            dataset = CocoDatasetInstanceSegmentation(data_directory_path='./data/1/images',
+                                                      data_annotation_path='./data/1/annotations/instances_default.json')
 
-    #         output_dir = os.path.join(temp_dir, 'output_patches')
-    #         patch_size = 64 
-    #         stride = 13
-    #         min_area = 100.0
-    #         dataset.extract_patches(output_dir, patch_size, stride, min_area)
+            output_dir = os.path.join(temp_dir, 'output_patches')
+            patch_size = 64 
+            stride = 13
+            min_area = 100.0
+            dataset.extract_patches(output_dir, patch_size, stride, min_area)
 
-    #         self.assertTrue(os.path.exists(output_dir))
-    #         self.assertTrue(os.path.exists(os.path.join(output_dir, 'images')))
-    #         self.assertTrue(os.path.exists(os.path.join(output_dir, 'annotations')))
-    #         self.assertTrue(os.path.exists(os.path.join(output_dir, 'annotations', 'annotations.json')))
+            self.assertTrue(os.path.exists(output_dir))
+            self.assertTrue(os.path.exists(os.path.join(output_dir, 'images')))
+            self.assertTrue(os.path.exists(os.path.join(output_dir, 'annotations')))
+            self.assertTrue(os.path.exists(os.path.join(output_dir, 'annotations', 'annotations.json')))
             
     def test_extended_dimensions(self):
         
@@ -37,6 +37,11 @@ class TestCocoDataset(unittest.TestCase):
         assert(extended_dimensions(256, 1, [50000, 50000000]) == [50000, 50000000])
         assert(extended_dimensions(256, 1, [123456, 987654]) == [123456, 987654])
         assert(extended_dimensions(256, 1, [1122554466, 12]) == [1122554466, 12])
+        
+        # For weird strides, still, the extension should fit the patches.
+        assert(extended_dimensions(4, 8, [10, 10]) == [12, 12])
+        assert(extended_dimensions(3, 8, [10, 10]) == [11, 11])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is important for patches at the edges, so they're generated with the same size of the other patches, which is necessary for training.