### PR TITLE
Bugfix - Wrong category_id and foreground size

### DIFF
--- a/src/dataset/dataset_coco.py
+++ b/src/dataset/dataset_coco.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Tuple
 import cv2
 import numpy as np
 import torch
+from scipy.stats import mode
 from torch.utils.data import DataLoader
 from tqdm import tqdm
 
@@ -292,12 +293,7 @@ class CocoDatasetInstanceSegmentation(CocoDataset):
                     # Extract data for each component and create a new annotation instance.
                     for label in np.unique(patch_map)[1:]:  # 0 is background
                         instance_map = np.array(patch_map == label, dtype=np.uint8)
-                        instance_category = patch_category_mask[patch_map == label][0]  # It could also be min().
-
-                        if instance_category not in [category["id"] for category in self.tree.data["categories"]]:
-                            print(f"Unknown category: {instance_category}")
-                            continue
-
+                        instance_category = mode(patch_category_mask[patch_map == label].flatten(), axis=0)[0][0]
                         instance_contours, _ = cv2.findContours(instance_map, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
                         instance_bbox = list(cv2.boundingRect(instance_contours[0]))
 

--- a/src/dataset/dataset_coco.py
+++ b/src/dataset/dataset_coco.py
@@ -293,7 +293,7 @@ class CocoDatasetInstanceSegmentation(CocoDataset):
                     # Extract data for each component and create a new annotation instance.
                     for label in np.unique(patch_map)[1:]:  # 0 is background
                         instance_map = np.array(patch_map == label, dtype=np.uint8)
-                        instance_category = mode(patch_category_mask[patch_map == label].flatten(), axis=0)[0][0]
+                        instance_category = mode(patch_category_mask[patch_map == label], axis=None, keepdims=False)[0]
                         instance_contours, _ = cv2.findContours(instance_map, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
                         instance_bbox = list(cv2.boundingRect(instance_contours[0]))
 

--- a/src/extras/dataset_patch_extraction.py
+++ b/src/extras/dataset_patch_extraction.py
@@ -22,10 +22,10 @@ def extract_patches(args: Dict) -> None:
     dataset = CocoDatasetInstanceSegmentation(args.get("images_path"), args.get("annotations_path"))
     patch_size = args.get("patch_size")
     stride = args.get("stride")
-    min_area_ratio = args.get("min_area_ratio")
+    min_area_percentage = args.get("min_area_percentage")
     output_path = args.get("output_path")
 
-    dataset.extract_patches(output_path, patch_size, stride, min_area_ratio)
+    dataset.extract_patches(output_path, patch_size, stride, min_area_percentage)
 
 
 def build_arg_parser() -> ArgumentParser:
@@ -75,9 +75,10 @@ def build_arg_parser() -> ArgumentParser:
     )
 
     parser.add_argument(
-        "--min-area-ratio",
+        "--min-area-percentage",
         type=float,
-        help="Patches with an area smaller than this ratio will be discarded.",
+        help="""Patches with foreground area smaller than min_area_percentage pixels in the patch will be discarded.
+            Defaults to 0.05.""",
         default=0.05,
         required=False,
     )


### PR DESCRIPTION
This branch comprises two bugfixes:
- Generation of wrong values for category_id (i.e. 7, 8, 9).
- Wrong logic for filtering patches with small objects