### PR TITLE
Ignore annotations from AI that are too small to be an actual rugae

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Where:
 
 - DATA_PATH is the path to a folder containing the dataset (images).
 
-## Image convertion script
+## Image conversion script
 
 There's a script that might be helpful if you need to convert images. In our case, from HEIC to something else that CVAT supports. 
 
@@ -29,6 +29,15 @@ Use it as such:
 
 ```shell
 ./scripts/image_converter.sh --from heic --to jpg --in /path/to/input/directory [--out /path/to/output/directory]
+```
+
+## Annotations info reader
+
+There's also a script to read info from an annotation file (TODO add format of the file) and provide useful information, 
+like biggest and smallest annotation (area), a CSV of annotation info or details about an image file.
+
+```shell
+python3 ./scripts/read_annotation_info.py ./data/manual/annotations/instances_default.json --summary --image_info 44 --image_info 687
 ```
 
 ## Dataset Preprocessing

--- a/scripts/read_annotation_info.py
+++ b/scripts/read_annotation_info.py
@@ -1,0 +1,86 @@
+import argparse
+import json
+import os
+from operator import itemgetter
+
+class Image:
+    def __init__(self, id, width, height):
+        self.id = id
+        self.width = width
+        self.height = height
+
+class Annotation:
+    def __init__(self, area, image_id):
+        self.area = area
+        self.image_id = image_id
+
+class Annotations:
+    def __init__(self, images, annotations):
+        self.images = images
+        self.annotations = annotations
+
+def main():
+    # Define command-line arguments
+    parser = argparse.ArgumentParser(description='Process JSON file containing annotations.')
+    parser.add_argument('json_file', metavar='JSON_FILE', type=str, help='Path to JSON file')
+    parser.add_argument('--csv', action='store_true', help='Print comma-separated values')
+    parser.add_argument('--summary', action='store_true', help='Include summary at the end')
+    args = parser.parse_args()
+
+    # Read JSON file
+    try:
+        with open(args.json_file, 'r') as file:
+            data = json.load(file)
+    except FileNotFoundError:
+        print("Error: File not found.")
+        return
+    except json.JSONDecodeError:
+        print("Error: Invalid JSON format.")
+        return
+
+    # Parse JSON data
+    try:
+        annotations = Annotations(
+            [Image(image['id'], image['width'], image['height']) for image in data['images']],
+            [Annotation(annotation['area'], annotation['image_id']) for annotation in data['annotations']]
+        )
+    except KeyError:
+        print("Error: JSON data missing required fields.")
+        return
+
+    # Sort annotations by area
+    annotations.annotations.sort(key=lambda x: x.area)
+
+    # Calculate image areas
+    image_areas = {image.id: image.width * image.height for image in annotations.images}
+
+    # Print CSV format if requested
+    if args.csv:
+        print_csv(annotations, image_areas)
+
+    # Print summary if requested
+    if args.summary:
+        print_summary(annotations, image_areas)
+
+def print_summary(annotations, image_areas):
+    # Print smallest annotation info
+    print("\nSmallest annotation info:")
+    print_annotation_info(annotations.annotations[0], image_areas)
+
+    # Print biggest annotation info
+    print("\nBiggest annotation info:")
+    print_annotation_info(annotations.annotations[-1], image_areas)
+
+def print_annotation_info(annotation, image_areas):
+    print(f"Area: {annotation.area:.2f}")
+    print(f"Image area: {image_areas[annotation.image_id]:.2f}")
+    print(f"Relative percentage: {(annotation.area / image_areas[annotation.image_id]) * 100:.2f}%")
+    print(f"Image ID: {annotation.image_id}")
+
+def print_csv(annotations, image_areas):
+    print("Annotation area,Image area,Annotation area percentage,Image ID")
+    for ann in annotations.annotations:
+        print(f"{ann.area:.2f},{image_areas[ann.image_id]:.2f},{(ann.area / image_areas[ann.image_id]) * 100:.20f},{ann.image_id}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/read_annotation_info.py
+++ b/scripts/read_annotation_info.py
@@ -1,23 +1,26 @@
 import argparse
 import json
-import os
-from operator import itemgetter
+
 
 class Image:
-    def __init__(self, id, width, height):
+    def __init__(self, id, width, height, filename):
         self.id = id
         self.width = width
         self.height = height
+        self.filename = filename
+
 
 class Annotation:
     def __init__(self, area, image_id):
         self.area = area
         self.image_id = image_id
 
+
 class Annotations:
     def __init__(self, images, annotations):
         self.images = images
         self.annotations = annotations
+
 
 def main():
     # Define command-line arguments
@@ -25,6 +28,8 @@ def main():
     parser.add_argument('json_file', metavar='JSON_FILE', type=str, help='Path to JSON file')
     parser.add_argument('--csv', action='store_true', help='Print comma-separated values')
     parser.add_argument('--summary', action='store_true', help='Include summary at the end')
+    parser.add_argument('--image_info', action='append', type=int,
+                        help='Show details for an image ID (can be specified multiple times)')
     args = parser.parse_args()
 
     # Read JSON file
@@ -41,7 +46,7 @@ def main():
     # Parse JSON data
     try:
         annotations = Annotations(
-            [Image(image['id'], image['width'], image['height']) for image in data['images']],
+            [Image(image['id'], image['width'], image['height'], image['file_name']) for image in data['images']],
             [Annotation(annotation['area'], annotation['image_id']) for annotation in data['annotations']]
         )
     except KeyError:
@@ -62,14 +67,43 @@ def main():
     if args.summary:
         print_summary(annotations, image_areas)
 
+    # Process image IDs if provided
+    if args.image_info:
+        process_image_ids(args.image_info, annotations)
+
+
+def process_image_ids(image_ids, annotations):
+    for image_id in image_ids:
+        print_image_info(annotations, image_id)
+
+
+def print_image_info(annotations, image_id):
+    found = False
+    for image in annotations.images:
+        if image.id == image_id:
+            print(f"Image ID: {image.id}")
+            print(f"Image width: {image.width}")
+            print(f"Image height: {image.height}")
+            print(f"Image filename: {image.filename}")
+            print()
+            found = True
+            break
+    if not found:
+        print(f"Image ID {image_id} not found.")
+        print()
+
+
 def print_summary(annotations, image_areas):
     # Print smallest annotation info
     print("\nSmallest annotation info:")
     print_annotation_info(annotations.annotations[0], image_areas)
+    print_image_info(annotations, annotations.annotations[0].image_id)
 
     # Print biggest annotation info
-    print("\nBiggest annotation info:")
+    print("Biggest annotation info:")
     print_annotation_info(annotations.annotations[-1], image_areas)
+    print_image_info(annotations, annotations.annotations[-1].image_id)
+
 
 def print_annotation_info(annotation, image_areas):
     print(f"Area: {annotation.area:.2f}")
@@ -77,10 +111,13 @@ def print_annotation_info(annotation, image_areas):
     print(f"Relative percentage: {(annotation.area / image_areas[annotation.image_id]) * 100:.2f}%")
     print(f"Image ID: {annotation.image_id}")
 
+
 def print_csv(annotations, image_areas):
     print("Annotation area,Image area,Annotation area percentage,Image ID")
     for ann in annotations.annotations:
-        print(f"{ann.area:.2f},{image_areas[ann.image_id]:.2f},{(ann.area / image_areas[ann.image_id]) * 100:.20f},{ann.image_id}")
+        print(
+            f"{ann.area:.2f},{image_areas[ann.image_id]:.2f},{(ann.area / image_areas[ann.image_id]) * 100:.20f},{ann.image_id}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Replaced by #38

With the current simple code, this what I'm getting in comparison with the current `master` code.

Before:
![ksnip_20240512-181401](https://github.com/laradru/ai-palatal-rugoscopy/assets/7481200/4bfac067-968f-4675-92e2-8adc41b9ee3e)

After:
![ksnip_20240512-181358](https://github.com/laradru/ai-palatal-rugoscopy/assets/7481200/b7b75614-7082-41f9-b6ec-924f46e92432)

I wonder why some tiny shapes still show up.
